### PR TITLE
Server v0.1.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -254,6 +254,7 @@ jobs:
           python-version: 3.x
       
       - name: Publish docs
+        working-directory: docs
         run: |
           pip install mkdocs-material
           mkdocs gh-deploy --force

--- a/server/server/Dockerfile
+++ b/server/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine AS builder
+FROM python:3.12-slim AS builder
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
@@ -15,7 +15,7 @@ COPY . /app/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-editable
 
-FROM python:3.12-alpine
+FROM python:3.12-slim
 
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 

--- a/server/server/pyproject.toml
+++ b/server/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "0.1.1"
+version = "0.1.2"
 description = "Core server component of Avala server"
 authors = [{ name = "Dušan Lazić", email = "lazicdusan@protonmail.com" }]
 requires-python = ">=3.12"

--- a/server/server/uv.lock
+++ b/server/server/uv.lock
@@ -948,7 +948,7 @@ wheels = [
 
 [[package]]
 name = "server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Changes

- Changes base image of the server from `python:3.12-alpine` to `python:3.12-slim`.

# Versions

Release the following versions of Avala components:

| Component       | Previous | New   |
|-----------------|----------|-------|
| avala-server    | 0.1.1        | 0.1.2 |
| avala-submitter | 0.1.1        | - |
| avala-client    | 0.1.0        | - |
